### PR TITLE
exclude Bundler's vendor directory from RuboCop run

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,9 @@ AllCops:
   Exclude:
     - 'tmp/**/*'
     - 'spec/fixtures/application/htdocs/stylesheets/**/config.rb'
-    - 'Vagrantfile'
     - 'config/**/*'
+    - 'Vagrantfile'
+    - 'vendor/**/*'
 GlobalVars:
   AllowedVariables: []
 MethodLength:


### PR DESCRIPTION
This increases utility of RuboCop run by removing useless warnings
